### PR TITLE
fix: update github api

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
           const prLabels = context.payload.pull_request.labels.map(label => label.name);
           const labelsToRemoveSet = new Set(labelsToRemove);
           const labelsToKeep = prLabels.filter(label => !labelsToRemoveSet.has(label));
-          await github.pulls.update({
+          await github.rest.pulls.update({
             ...context.repo,
             pull_number: context.payload.pull_request.number,
             labels: labelsToKeep


### PR DESCRIPTION
Update the github api. In the newer versions of the GitHub Script action, the API methods are under the rest namespace.